### PR TITLE
Unify the company name (Litware --> Contoso) across MD files and fix broken link in WDS student guide

### DIFF
--- a/Hands-on lab/HOL step-by-step - Serverless architecture.md
+++ b/Hands-on lab/HOL step-by-step - Serverless architecture.md
@@ -86,7 +86,7 @@ At the end of the hands-on-lab, you will have confidence in designing, developin
 
 ## Overview
 
-Litware, Inc. is rapidly expanding their toll booth management business to operate in a much larger area. As this is not their primary business, which is online payment services, they are struggling with scaling up to meet the upcoming demand to extract license plate information from a large number of new tollbooths, using photos of vehicles uploaded to cloud storage. Currently, they have a manual process where they send batches of photos to a 3rd-party who manually transcodes the license plates to CSV files that they send back to Litware to upload to their online processing system. They want to automate this process in a way that is cost effective and scalable. They believe serverless is the best route for them, but do not have the expertise to build the solution.
+Contoso, ltd. is rapidly expanding their toll booth management business to operate in a much larger area. As this is not their primary business, which is online payment services, they are struggling with scaling up to meet the upcoming demand to extract license plate information from a large number of new tollbooths, using photos of vehicles uploaded to cloud storage. Currently, they have a manual process where they send batches of photos to a 3rd-party who manually transcodes the license plates to CSV files that they send back to Contoso to upload to their online processing system. They want to automate this process in a way that is cost effective and scalable. They believe serverless is the best route for them, but do not have the expertise to build the solution.
 
 ## Solution architecture
 

--- a/Hands-on lab/HOL unguided - Serverless architecture.md
+++ b/Hands-on lab/HOL unguided - Serverless architecture.md
@@ -140,7 +140,7 @@ At the end of the hands-on-lab, you will have confidence in designing, developin
 
 ## Overview
 
-Litware, Inc. is rapidly expanding their toll booth management business to operate in a much larger area. As this is not their primary business, which is online payment services, they are struggling with scaling up to meet the upcoming demand to extract license plate information from a large number of new tollbooths, using photos of vehicles uploaded to cloud storage. Currently, they have a manual process where they send batches of photos to a 3rd-party who manually transcodes the license plates to CSV files that they send back to Litware to upload to their online processing system. They want to automate this process in a way that is cost effective and scalable. They believe serverless is the best route for them, but do not have the expertise to build the solution.
+Contoso, ltd. is rapidly expanding their toll booth management business to operate in a much larger area. As this is not their primary business, which is online payment services, they are struggling with scaling up to meet the upcoming demand to extract license plate information from a large number of new tollbooths, using photos of vehicles uploaded to cloud storage. Currently, they have a manual process where they send batches of photos to a 3rd-party who manually transcodes the license plates to CSV files that they send back to Contoso to upload to their online processing system. They want to automate this process in a way that is cost effective and scalable. They believe serverless is the best route for them, but do not have the expertise to build the solution.
 
 ## Solution architecture
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Serverless architecture
 
-Litware, Inc. is rapidly expanding their toll booth management business to operate in a much larger area. As this is not their primary business, which is online payment services, they are struggling with scaling up to meet the upcoming demand to extract license plate information from a large number of new tollbooths, using photos of vehicles uploaded to cloud storage. Currently, they have a manual process where they send batches of photos to a 3rd-party who manually transcodes the license plates to CSV files that they send back to Litware to upload to their online processing system. 
+Contoso, ltd. is rapidly expanding their toll booth management business to operate in a much larger area. As this is not their primary business, which is online payment services, they are struggling with scaling up to meet the upcoming demand to extract license plate information from a large number of new tollbooths, using photos of vehicles uploaded to cloud storage. Currently, they have a manual process where they send batches of photos to a 3rd-party who manually transcodes the license plates to CSV files that they send back to Contoso to upload to their online processing system. 
 
 They want to automate this process in a way that is cost effective and scalable. They believe serverless is the best route for them, but do not have the expertise to build the solution.
 

--- a/Whiteboard design session/WDS student guide - Serverless architecture.md
+++ b/Whiteboard design session/WDS student guide - Serverless architecture.md
@@ -224,7 +224,7 @@ Timeframe: 15 minutes
 | Choose between Azure services that deliver messages |                    <https://docs.microsoft.com/en-us/azure/event-grid/compare-messaging-services>                     |
 | Monitor Azure Functions using Application Insights  |                     <https://docs.microsoft.com/en-us/azure/azure-functions/functions-monitoring>                     |
 | Introduction to Azure Event Grid                    |                             <https://docs.microsoft.com/en-us/azure/event-grid/overview>                              |
-| Call Azure Functions from logic apps                | <https://docs.microsoft.com/en-us/azure/logic-apps/logic-apps-azure-functions%23call-azure-functions-from-logic-apps> |
+| Call Azure Functions from logic apps                | <https://docs.microsoft.com/en-us/azure/logic-apps/logic-apps-azure-functions> |
 | Azure Cosmos DB + Azure Functions                   |                   <https://docs.microsoft.com/en-us/azure/cosmos-db/serverless-computing-database>                    |
 | Continuous deployment of Azure Functions            |               <https://docs.microsoft.com/en-us/azure/azure-functions/functions-continuous-deployment>                |
 | Code and test Azure Functions locally               |                     <https://docs.microsoft.com/en-us/azure/azure-functions/functions-run-local>                      |


### PR DESCRIPTION
Two updates in documentation files:

- Replaced Litware with Contoso to align all MD files with the rest of the material (PPTX). A small fix but improves consistency in the repository.
- Fixed broken link for 'Call Azure Functions from logic apps' reference in 'Additional references' table at the bottom of 'WDS student guide - Serverless architecture.md'

