### PR TITLE
Correct default setting for Endpoints to Functions

### DIFF
--- a/Hands-on lab/HOL step-by-step - Serverless architecture.md
+++ b/Hands-on lab/HOL step-by-step - Serverless architecture.md
@@ -687,7 +687,7 @@ In this task, you will publish the Function App from the starter project in Visu
 
     f. Select only the **Blob Created** from the event types dropdown list.
 
-    g. Leave Web Hook as the Endpoint Type.
+    g. Leave the default Azure Function as the Endpoint Type, with endpoint **ProcessImage**.
 
 13. Leave the remaining fields at their default values and select **Create**.
 
@@ -785,7 +785,7 @@ In this task, you will add an Event Grid subscription to the SavePlateData funct
 
     g. Enter `savePlateData` for the new event type value. This will ensure this function is only triggered by this Event Grid type.
 
-    h. Leave Web Hook as the Endpoint Type.
+    h. Leave the default Azure Function as the Endpoint Type, with endpoint **SavePlateData**.
 
 3. Leave the remaining fields at their default values and select **Create**.
 
@@ -891,7 +891,7 @@ In this task, you will add an Event Grid subscription to the QueuePlateForManual
 
     g. Enter `queuePlateForManualCheckup` for the new event type value. This will ensure this function is only triggered by this Event Grid type.
 
-    h. Leave Web Hook as the Endpoint Type.
+    h. Leave the default Azure Function as the Endpoint Type, with endpoint **QueuePlateForManualCheckup**..
 
 3. Leave the remaining fields at their default values and select **Create**.
 


### PR DESCRIPTION
For instance in Exercise 2, Task 2 and 5, bulletpoint 2.h - when adding a Event Grid subscription to a function, where it says "Leave webhook, it's incorrect. We have to leave the default Azure Function (points to itself). The UI by default suggests the endpoint to Azure Function, to itself